### PR TITLE
Added a CodecFactoryFactory type so that you can register new container types

### DIFF
--- a/preon-binding/src/main/java/org/codehaus/preon/CodecFactoryFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/CodecFactoryFactory.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2009-2010 Wilfred Springer
+ *
+ * This file is part of Preon.
+ *
+ * Preon is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 2, or (at your option) any later version.
+ *
+ * Preon is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * Preon; see the file COPYING. If not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Linking this library statically or dynamically with other modules is making a
+ * combined work based on this library. Thus, the terms and conditions of the
+ * GNU General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent modules, and
+ * to copy and distribute the resulting executable under terms of your choice,
+ * provided that you also meet, for each linked independent module, the terms
+ * and conditions of the license of that module. An independent module is a
+ * module which is not derived from or based on this library. If you modify this
+ * library, you may extend this exception to your version of the library, but
+ * you are not obligated to do so. If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+package org.codehaus.preon;
+
+import java.lang.reflect.AnnotatedElement;
+
+
+/**
+ * A factory for {@link Codec Codecs}. A {@link CodecFactoryFactory} is not tightly coupled to a certain type of {@link
+ * Codec}.
+ *
+ * @author Wifred Springer
+ */
+public interface CodecFactoryFactory {
+
+	CodecFactory create(CodecFactory delegate);
+
+}

--- a/preon-binding/src/main/java/org/codehaus/preon/DefaultCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/DefaultCodecFactory.java
@@ -72,6 +72,25 @@ public class DefaultCodecFactory implements CodecFactory {
                                CodecDecorator[] addOnDecorators,
                                BindingDecorator[] bindingDecorators)
     {
+    	CodecFactoryFactory[] codecFactoryFactory = new CodecFactoryFactory[addOnFactories.length];
+    	int i = 0;
+    	for (CodecFactory codecFactory : addOnFactories) {
+    		codecFactoryFactory[i] = new InstanceFactoryFactory(codecFactory);
+    	}
+    	
+    	return create(metadata,
+                type,
+                codecFactoryFactory,
+                addOnDecorators,
+                bindingDecorators);
+    }
+    
+    public <T> Codec<T> create(AnnotatedElement metadata,
+            Class<T> type,
+            CodecFactoryFactory[] addOnFactoryFactories,
+            CodecDecorator[] addOnDecorators,
+            BindingDecorator[] bindingDecorators)
+{
 
         // The actual cache of Codecs.
         final List<Codec<?>> created = new ArrayList<Codec<?>>();
@@ -99,8 +118,8 @@ public class DefaultCodecFactory implements CodecFactory {
                 decorators);
 
         // Add additional CodecFactories passed in.
-        for (CodecFactory factory : addOnFactories) {
-            codecFactory.add(factory);
+        for (CodecFactoryFactory factory : addOnFactoryFactories) {
+            codecFactory.add(factory.create(top));
         }
 
         // Add other default CodecFactories.

--- a/preon-binding/src/main/java/org/codehaus/preon/InstanceFactoryFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/InstanceFactoryFactory.java
@@ -1,0 +1,15 @@
+package org.codehaus.preon;
+
+public class InstanceFactoryFactory implements CodecFactoryFactory {
+	
+	CodecFactory codecFactoryInstance;
+	
+	InstanceFactoryFactory (CodecFactory codecFactoryInstance) {
+		this.codecFactoryInstance = codecFactoryInstance;
+	}
+
+	public CodecFactory create(CodecFactory delegate) {
+		return codecFactoryInstance;
+	}
+
+}


### PR DESCRIPTION
I needed to make a new type of list: a BitSizedList, for which only the full size of the list was specified and the list elements were variably sized.

I was unable to make such a type work without adding a new type that would take the fully decorated top factory.

This is the core preon code that I had to add to make this work.