### PR TITLE
Added support for little endian encoding

### DIFF
--- a/preon-binding/pom.xml
+++ b/preon-binding/pom.xml
@@ -42,6 +42,11 @@
       <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/preon-binding/pom.xml
+++ b/preon-binding/pom.xml
@@ -21,7 +21,7 @@
   </repositories>
   <dependencies>
     <dependency>
-      <groupId>multithreadedtc</groupId>
+      <groupId>edu.umd.cs.mtc</groupId>
       <artifactId>multithreadedtc</artifactId>
       <version>1.01</version>
       <scope>test</scope>

--- a/preon-binding/src/main/java/org/codehaus/preon/Codec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/Codec.java
@@ -62,6 +62,22 @@ public interface Codec<T> {
             throws DecodingException;
 
     /**
+     * Decodes a value from the {@link BitBuffer}.
+     *
+     * @param buffer   The {@link BitBuffer} containing the data from which a value will be decoded.
+     * @param resolver The object capable of resolving variable references, when required.
+     * @param builder  The object responsible for creating default instances of objects, when needed. (In reality, this
+     *                 is most likely going to be important to {@link org.codehaus.preon.codec.ObjectCodecFactory
+     *                 ObjectCodecFactories} only, but in order to make sure the {@link Builder} arrives there, we need
+     *                 to have the ability to pass it in.
+     * @param debug    Prints debug to screen while decoding.
+     * @return The decoded value.
+     * @throws DecodingException If the {@link Codec} fails to decode the value.
+     */
+    T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException;
+
+    /**
      * Encodes the object to the {@link org.codehaus.preon.channel.BitChannel}.
      *
      * @param value    The object to encode.

--- a/preon-binding/src/main/java/org/codehaus/preon/Codecs.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/Codecs.java
@@ -166,6 +166,89 @@ public class Codecs {
 
     /**
      * Decodes an object from the buffer passed in.
+     * Also prints Debug to System out
+     *
+     * @param <T>    The of object to be decoded.
+     * @param codec  The {@link Codec} that will take care of the actual work.
+     * @param buffer An array of bytes holding the encoded data.
+     * @return The decoded object.
+     * @throws DecodingException If the {@link Codec} fails to decode a value from the buffer passed in.
+     */
+    public static <T> T decodeDebug(Codec<T> codec, byte... buffer)
+            throws DecodingException {
+        return decodeDebug(codec, ByteBuffer.wrap(buffer));
+    }
+
+    public static <T> T decodeDebug(Codec<T> codec, Builder builder, byte... buffer)
+            throws DecodingException {
+        return decodeDebug(codec, ByteBuffer.wrap(buffer), builder);
+    }
+
+    /**
+     * Decodes an object from the buffer passed in.
+     * Also prints Debug to System out
+     *
+     * @param <T>    The of object to be decoded.
+     * @param codec  The {@link Codec} that will take care of the actual work.
+     * @param buffer An array of bytes holding the encoded data.
+     * @return The decoded object.
+     * @throws DecodingException If the {@link Codec} fails to decode a value from the buffer passed in.
+     */
+    public static <T> T decodeDebug(Codec<T> codec, ByteBuffer buffer)
+            throws DecodingException {
+        return decodeDebug(codec, new DefaultBitBuffer(buffer), null, null);
+    }
+
+    public static <T> T decodeDebug(Codec<T> codec, ByteBuffer buffer, Builder builder)
+            throws DecodingException {
+        return decodeDebug(codec, new DefaultBitBuffer(buffer), builder, null);
+    }
+
+    public static <T> T decodeDebug(Codec<T> codec, BitBuffer buffer, Builder builder, Resolver resolver)
+            throws DecodingException {
+        if (builder == null) {
+            builder = DEFAULT_BUILDER;
+        }
+        return codec.decode(buffer, resolver, builder, true);
+    }
+
+    /**
+     * Decodes an object from the buffer passed in.
+     * Also prints Debug to System out
+     *
+     * @param <T>   The of object to be decoded.
+     * @param codec The {@link Codec} that will take care of the actual work.
+     * @param file  The {@link File} providing the data to be decoded.
+     * @return The decoded object.
+     * @throws FileNotFoundException If the {@link File} does not exist.
+     * @throws IOException           If the system fails to read data from the file.
+     * @throws DecodingException     If the {@link Codec} fails to decode a value from the buffer passed in.
+     */
+    public static <T> T decodeDebug(Codec<T> codec, File file)
+            throws FileNotFoundException, IOException, DecodingException {
+        return decodeDebug(codec, null, file);
+    }
+
+    public static <T> T decodeDebug(Codec<T> codec, Builder builder, File file)
+            throws FileNotFoundException, IOException, DecodingException {
+        FileInputStream in = null;
+        FileChannel channel = null;
+        try {
+            in = new FileInputStream(file);
+            channel = in.getChannel();
+            int fileSize = (int) channel.size();
+            ByteBuffer buffer = channel.map(FileChannel.MapMode.READ_ONLY, 0,
+                    fileSize);
+            return decodeDebug(codec, buffer, builder);
+        } finally {
+            if (channel != null) {
+                channel.close();
+            }
+        }
+    }
+
+    /**
+     * Decodes an object from the buffer passed in.
      *
      * @param <T>    The of object to be decoded.
      * @param codec  The {@link Codec} that will take care of the actual work.

--- a/preon-binding/src/main/java/org/codehaus/preon/Codecs.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/Codecs.java
@@ -256,6 +256,7 @@ public class Codecs {
      */
     public static <T> void encode(T value, Codec<T> codec, BitChannel channel) throws IOException {
         codec.encode(value, channel, new NullResolver());
+        channel.flush();
     }
 
     public static <T> byte[] encode(T value, Codec<T> codec) throws IOException {

--- a/preon-binding/src/main/java/org/codehaus/preon/Codecs.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/Codecs.java
@@ -344,7 +344,11 @@ public class Codecs {
         int bitsUsedInLastByte = encode(value, codec, out, byteOrder);
         byte[] finalBytes = out.toByteArray();
 
-        numBits.setValue((finalBytes.length - 1) * 8 + bitsUsedInLastByte);
+        if(bitsUsedInLastByte == 0) {
+            numBits.setValue(finalBytes.length * 8);
+        } else {
+            numBits.setValue((finalBytes.length - 1) * 8 + bitsUsedInLastByte);
+        }
 
         return finalBytes;
     }

--- a/preon-binding/src/main/java/org/codehaus/preon/DefaultCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/DefaultCodecFactory.java
@@ -159,6 +159,11 @@ public class DefaultCodecFactory implements CodecFactory {
             return delegate.decode(buffer, resolver, builder);
         }
 
+        public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+                throws DecodingException {
+            return delegate.decode(buffer, resolver, builder, debug);
+        }
+
         public void encode(T value, BitChannel channel, Resolver resolver) throws IOException {
             delegate.encode(value, channel, resolver);
         }

--- a/preon-binding/src/main/java/org/codehaus/preon/ExtendedCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/ExtendedCodec.java
@@ -38,4 +38,5 @@ public interface ExtendedCodec<T> extends Codec<T> {
 
     void encode(T object, BitChannel channel, Resolver resolver);
 
+    void encode(T object, BitChannel channel, Resolver resolver, boolean debug);
 }

--- a/preon-binding/src/main/java/org/codehaus/preon/annotation/BoundString.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/annotation/BoundString.java
@@ -32,8 +32,6 @@
  */
 package org.codehaus.preon.annotation;
 
-import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -76,12 +74,12 @@ public @interface BoundString {
      *
      * @return The String that needs to be matched. Or the empty String if matching is not important.
      */
-     
+
     String match() default "";
-    
+
     /* I've left this in, but I don't use this code anywhere in the actual
      * factory. It might be possible to alter the factories to use
-     * ByteConverters, by wrapping around ByteBuffer in some clever way, 
+     * ByteConverters, by wrapping around ByteBuffer in some clever way,
      * but my feeling is that the aims of this code would be better
      * achieved by Charsets.
      * */

--- a/preon-binding/src/main/java/org/codehaus/preon/binding/Binding.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/binding/Binding.java
@@ -80,6 +80,30 @@ public interface Binding {
               Builder builder) throws DecodingException;
 
     /**
+     * Loads a value from the {@link BitBuffer} and uses the value to populate a
+     * field on the object.
+     *
+     * @param object
+     *            The Object on which fields need to be populated.
+     * @param buffer
+     *            The buffer from which data will be taken.
+     * @param resolver
+     *            The object capable of returning values for references passed
+     *            in.
+     * @param builder
+     *            The builder that will be used when - while loading data from
+     *            the {@link BitBuffer} - the Binding is (indirectly) required
+     *            to create a default instance of a type.
+     * @param debug
+     *            Prints debug to screen while decoding.
+     * @throws DecodingException
+     *             If we fail to decode the fields value from the
+     *             {@link BitBuffer}.
+     */
+    void load(Object object, BitBuffer buffer, Resolver resolver,
+              Builder builder, boolean debug) throws DecodingException;
+
+    /**
      * Describes this {@link Binding} in the paragraph passed in.
      *
      * @param <T>

--- a/preon-binding/src/main/java/org/codehaus/preon/binding/ConditionalBindingFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/binding/ConditionalBindingFactory.java
@@ -114,6 +114,13 @@ public class ConditionalBindingFactory implements BindingFactory {
             }
         }
 
+        public void load(Object object, BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+                throws DecodingException {
+            if (expr.eval(resolver)) {
+                binding.load(object, buffer, resolver, builder, debug);
+            }
+        }
+
         public <T, V extends ParaContents<T>> V describe(final V contents) {
             contents.text(" Only if ");
             expr.document(new Document() {

--- a/preon-binding/src/main/java/org/codehaus/preon/binding/StandardBindingFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/binding/StandardBindingFactory.java
@@ -99,11 +99,25 @@ public class StandardBindingFactory implements BindingFactory {
 
         public void load(Object object, BitBuffer buffer, Resolver resolver,
                          Builder builder) throws DecodingException {
+            load(object, buffer, resolver, builder, false);
+        }
+
+        public void load(Object object, BitBuffer buffer, Resolver resolver,
+                         Builder builder, boolean debug) throws DecodingException {
             try {
                 ReflectionUtils.makeAssessible(field);
+
+                long beforePos = buffer.getActualBitPos();
+
                 Object value = codec.decode(buffer, resolver, builderDecorator
-                        .decorate(builder, object));
+                        .decorate(builder, object), debug);
                 field.set(object, value);
+
+                long afterPos = buffer.getActualBitPos();
+
+                if(debug) {
+                    System.out.println(field.getName() + " = " + value + " (bits: " + beforePos + " to " + afterPos + ")");
+                }
             } catch (IllegalAccessException iae) {
                 throw new DecodingException(iae);
             } catch (DecodingException de) {

--- a/preon-binding/src/main/java/org/codehaus/preon/binding/StandardBindingFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/binding/StandardBindingFactory.java
@@ -116,7 +116,7 @@ public class StandardBindingFactory implements BindingFactory {
                 long afterPos = buffer.getActualBitPos();
 
                 if(debug) {
-                    System.out.println(field.getName() + " = " + value + " (bits: " + beforePos + " to " + afterPos + ")");
+                    System.out.println(field.getName() + " = " + value + " (bits: " + beforePos + " to " + (afterPos-1) + ")");
                 }
             } catch (IllegalAccessException iae) {
                 throw new DecodingException(iae);

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ArrayCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ArrayCodec.java
@@ -85,10 +85,15 @@ class ArrayCodec implements Codec<Object> {
 
     public Object decode(BitBuffer buffer, Resolver resolver,
                          Builder builder) throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public Object decode(BitBuffer buffer, Resolver resolver,
+                         Builder builder, boolean debug) throws DecodingException {
         int length = size.eval(resolver).intValue();
         Object result = Array.newInstance(type.getComponentType(), length);
         for (int i = 0; i < length; i++) {
-            Object value = codec.decode(buffer, resolver, builder);
+            Object value = codec.decode(buffer, resolver, builder, debug);
             Array.set(result, i, value);
         }
         return result;

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/BooleanCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/BooleanCodecFactory.java
@@ -40,6 +40,7 @@ import nl.flotsam.pecia.SimpleContents;
 import org.codehaus.preon.*;
 import org.codehaus.preon.annotation.Bound;
 import org.codehaus.preon.buffer.BitBuffer;
+import org.codehaus.preon.buffer.ByteOrder;
 import org.codehaus.preon.channel.BitChannel;
 
 import java.io.IOException;
@@ -63,9 +64,11 @@ public class BooleanCodecFactory implements CodecFactory {
                                ResolverContext context) {
         if (metadata == null || metadata.isAnnotationPresent(Bound.class)) {
             if (boolean.class.equals(type)) {
-                return (Codec<T>) new BooleanCodec(true);
+            	  ByteOrder endian = ByteOrder.BigEndian;
+                return (Codec<T>) new BooleanCodec(true, endian);
             } else if (Boolean.class.equals(type)) {
-                return (Codec<T>) new BooleanCodec(false);
+            	  ByteOrder endian = ByteOrder.BigEndian;
+                return (Codec<T>) new BooleanCodec(false, endian);
             } else {
                 return null;
             }
@@ -77,9 +80,12 @@ public class BooleanCodecFactory implements CodecFactory {
     private static class BooleanCodec implements Codec<Boolean> {
 
         private boolean primitive;
+        
+    	  protected ByteOrder byteOrder;
 
-        public BooleanCodec(boolean primitive) {
+        public BooleanCodec(boolean primitive, ByteOrder byteOrder) {
             this.primitive = primitive;
+            this.byteOrder = byteOrder;
         }
 
         public Boolean decode(BitBuffer buffer, Resolver resolver,
@@ -88,7 +94,7 @@ public class BooleanCodecFactory implements CodecFactory {
         }
 
         public void encode(Boolean value, BitChannel channel, Resolver resolver) throws IOException {
-            channel.write(value);
+            channel.write(value, byteOrder);
         }
 
         public CodecDescriptor getCodecDescriptor() {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/BooleanCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/BooleanCodecFactory.java
@@ -93,6 +93,11 @@ public class BooleanCodecFactory implements CodecFactory {
             return buffer.readAsBoolean();
         }
 
+        public Boolean decode(BitBuffer buffer, Resolver resolver,
+                              Builder builder, boolean debug) throws DecodingException {
+            return buffer.readAsBoolean();
+        }
+
         public void encode(Boolean value, BitChannel channel, Resolver resolver) throws IOException {
             channel.write(value, byteOrder);
         }

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/BoundBufferCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/BoundBufferCodecFactory.java
@@ -71,6 +71,11 @@ public class BoundBufferCodecFactory implements CodecFactory {
 
         public Object decode(BitBuffer buffer, Resolver resolver,
                              Builder builder) throws DecodingException {
+            return decode(buffer, resolver, builder, false);
+        }
+
+        public Object decode(BitBuffer buffer, Resolver resolver,
+                             Builder builder, boolean debug) throws DecodingException {
             for (int i = 0; i < criterion.length; i++) {
                 if (criterion[i] != buffer.readAsByte(8)) {
                     throw new DecodingException("First " + criterion.length

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ByteAligningDecorator.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ByteAligningDecorator.java
@@ -72,7 +72,12 @@ public class ByteAligningDecorator implements CodecDecorator {
 
         public T decode(BitBuffer buffer, Resolver resolver, Builder builder)
                 throws DecodingException {
-            return decode(buffer, resolver, builder, false);
+            T result = decorated.decode(buffer, resolver, builder);
+            long pos = buffer.getBitPos() % 8;
+            if (pos > 0) {
+                buffer.setBitPos(buffer.getBitPos() + 8 - pos);
+            }
+            return result;
         }
 
         public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ByteAligningDecorator.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ByteAligningDecorator.java
@@ -72,7 +72,12 @@ public class ByteAligningDecorator implements CodecDecorator {
 
         public T decode(BitBuffer buffer, Resolver resolver, Builder builder)
                 throws DecodingException {
-            T result = decorated.decode(buffer, resolver, builder);
+            return decode(buffer, resolver, builder, false);
+        }
+
+        public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+                throws DecodingException {
+            T result = decorated.decode(buffer, resolver, builder, debug);
             long pos = buffer.getBitPos() % 8;
             if (pos > 0) {
                 buffer.setBitPos(buffer.getBitPos() + 8 - pos);

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/CachingCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/CachingCodecFactory.java
@@ -171,6 +171,11 @@ public class CachingCodecFactory implements CodecFactory {
             return codec.decode(buffer, resolver, builder);
         }
 
+        public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+                throws DecodingException {
+            return codec.decode(buffer, resolver, builder, debug);
+        }
+
         public void encode(T value, BitChannel channel, Resolver resolver) throws IOException {
             codec.encode(value, channel, resolver);
         }

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/EnumCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/EnumCodec.java
@@ -85,6 +85,11 @@ public class EnumCodec<T> implements Codec<T> {
 
     public T decode(BitBuffer buffer, Resolver resolver, Builder builder)
             throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException {
         long value = buffer.readAsLong(size.eval(resolver), byteOrder);
         T result = mapping.get(value);
         if (result == null) {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/FixedLengthStringCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/FixedLengthStringCodec.java
@@ -82,6 +82,11 @@ public class FixedLengthStringCodec implements Codec<String> {
 
     public String decode(BitBuffer buffer, Resolver resolver,
                          Builder builder) throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public String decode(BitBuffer buffer, Resolver resolver,
+                         Builder builder, boolean debug) throws DecodingException {
 		/* This takes a slice of the BitBuffer as a ByteBuffer,
 		 * and feeds it into encoding.decode.
 		 * */

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/FixedLengthStringCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/FixedLengthStringCodec.java
@@ -32,24 +32,27 @@
  */
 package org.codehaus.preon.codec;
 
-import org.codehaus.preon.el.Expression;
-import org.codehaus.preon.el.Expressions;
-import nl.flotsam.pecia.Documenter;
-import nl.flotsam.pecia.ParaContents;
-import nl.flotsam.pecia.SimpleContents;
-import org.codehaus.preon.*;
-import org.codehaus.preon.annotation.BoundString;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
-import java.io.StringWriter;
-import java.nio.BufferUnderflowException;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+
+import org.codehaus.preon.Builder;
+import org.codehaus.preon.Codec;
+import org.codehaus.preon.CodecDescriptor;
+import org.codehaus.preon.DecodingException;
+import org.codehaus.preon.Resolver;
+import org.codehaus.preon.annotation.BoundString;
 import org.codehaus.preon.buffer.BitBuffer;
 import org.codehaus.preon.channel.BitChannel;
 import org.codehaus.preon.descriptor.Documenters;
+import org.codehaus.preon.el.Expression;
+import org.codehaus.preon.el.Expressions;
 
-import java.io.IOException;
+import nl.flotsam.pecia.Documenter;
+import nl.flotsam.pecia.ParaContents;
+import nl.flotsam.pecia.SimpleContents;
 
 /**
  * A {@link org.codehaus.preon.Codec} decoding Strings based on a fixed number of <em>bytes</em>. (Note that it says
@@ -58,7 +61,7 @@ import java.io.IOException;
 public class FixedLengthStringCodec implements Codec<String> {
 
     private final Charset encoding;
-    
+
     private final CharsetEncoder encoder;
 
     private final Expression<Integer, Resolver> sizeExpr;
@@ -112,7 +115,7 @@ public class FixedLengthStringCodec implements Codec<String> {
             bytebuffer.put(new byte[size - bytebuffer.position()]);
         }
         bytebuffer.flip(); // switch to reading
-        
+
         byte[] bytes = new byte[size];
         bytebuffer.get(bytes);
         for (int i = 0; i < bytes.length; i++) {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/InitCodecDecorator.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/InitCodecDecorator.java
@@ -105,7 +105,12 @@ public class InitCodecDecorator implements CodecDecorator {
 
         public T decode(BitBuffer buffer, Resolver resolver, Builder builder)
                 throws DecodingException {
-            T result = codec.decode(buffer, resolver, builder);
+            return decode(buffer, resolver, builder, false);
+        }
+
+        public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+                throws DecodingException {
+            T result = codec.decode(buffer, resolver, builder, debug);
             if (result != null) {
                 try {
                     method.invoke(result);

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/LazyLoadingCodecDecorator.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/LazyLoadingCodecDecorator.java
@@ -108,6 +108,12 @@ public class LazyLoadingCodecDecorator implements CodecDecorator {
         @SuppressWarnings("unchecked")
         public T decode(final BitBuffer buffer, final Resolver resolver,
                         final Builder builder) throws DecodingException {
+            return decode(buffer, resolver, builder, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public T decode(final BitBuffer buffer, final Resolver resolver,
+                        final Builder builder, boolean debug) throws DecodingException {
             final int size = wrapped.getSize().eval(resolver);
             final long pos = buffer.getBitPos();
             ClassLoader loader = this.getClass().getClassLoader();

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ListBasedMapCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ListBasedMapCodec.java
@@ -58,7 +58,12 @@ public class ListBasedMapCodec<K,V> implements Codec<Map<K,V>> {
     }
 
     public Map<K,V> decode(BitBuffer buffer, Resolver resolver, Builder builder) throws DecodingException {
-        List<? extends Map.Entry<K, V>> entries = listCodec.decode(buffer, resolver, builder);
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public Map<K,V> decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException {
+        List<? extends Map.Entry<K, V>> entries = listCodec.decode(buffer, resolver, builder, debug);
         Map<K,V> result = new HashMap(entries.size());
         for (Map.Entry<K, V> entry : entries) {
             result.put(entry.getKey(), entry.getValue());

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ListBasedMapCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ListBasedMapCodec.java
@@ -58,7 +58,12 @@ public class ListBasedMapCodec<K,V> implements Codec<Map<K,V>> {
     }
 
     public Map<K,V> decode(BitBuffer buffer, Resolver resolver, Builder builder) throws DecodingException {
-        return decode(buffer, resolver, builder, false);
+        List<? extends Map.Entry<K, V>> entries = listCodec.decode(buffer, resolver, builder);
+        Map<K,V> result = new HashMap(entries.size());
+        for (Map.Entry<K, V> entry : entries) {
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result;
     }
 
     public Map<K,V> decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ListCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ListCodecFactory.java
@@ -39,15 +39,6 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.codehaus.preon.el.BindingException;
-import org.codehaus.preon.el.Document;
-import org.codehaus.preon.el.Expression;
-import org.codehaus.preon.el.Expressions;
-import org.codehaus.preon.el.Reference;
-import org.codehaus.preon.el.ReferenceContext;
-import nl.flotsam.pecia.Documenter;
-import nl.flotsam.pecia.ParaContents;
-import nl.flotsam.pecia.SimpleContents;
 import org.codehaus.preon.Builder;
 import org.codehaus.preon.Codec;
 import org.codehaus.preon.CodecConstructionException;
@@ -66,13 +57,21 @@ import org.codehaus.preon.buffer.SlicedBitBuffer;
 import org.codehaus.preon.channel.BitChannel;
 import org.codehaus.preon.descriptor.Documenters;
 import org.codehaus.preon.descriptor.NullCodecDescriptor2;
+import org.codehaus.preon.el.BindingException;
 import org.codehaus.preon.el.ContextReplacingReference;
+import org.codehaus.preon.el.Document;
+import org.codehaus.preon.el.Expression;
+import org.codehaus.preon.el.Expressions;
+import org.codehaus.preon.el.Reference;
+import org.codehaus.preon.el.ReferenceContext;
 import org.codehaus.preon.util.AnnotationWrapper;
 import org.codehaus.preon.util.CodecDescriptorHolder;
 import org.codehaus.preon.util.EvenlyDistributedLazyList;
 import org.codehaus.preon.util.ParaContentsDocument;
 
-import javax.annotation.Nullable;
+import nl.flotsam.pecia.Documenter;
+import nl.flotsam.pecia.ParaContents;
+import nl.flotsam.pecia.SimpleContents;
 
 /**
  * A {@link CodecFactory} capable of supporting Lists. <p/> <p> There are a couple of cases that we need to clarify.

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ListCodecFactory.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ListCodecFactory.java
@@ -32,6 +32,7 @@
  */
 package org.codehaus.preon.codec;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
@@ -263,8 +264,10 @@ public class ListCodecFactory implements CodecFactory {
                     buffer, size.eval(resolver), builder, resolver, elementSize.eval(resolver));
         }
 
-        public void encode(List<T> value, BitChannel channel, Resolver resolver) {
-            throw new UnsupportedOperationException();
+        public void encode(List<T> value, BitChannel channel, Resolver resolver) throws IOException {
+            for (T val : value) {
+                codec.encode(val, channel, resolver);
+            }
         }
 
         public Class<?>[] getTypes() {
@@ -375,8 +378,10 @@ public class ListCodecFactory implements CodecFactory {
             return result;
         }
 
-        public void encode(List<T> value, BitChannel channel, Resolver resolver) {
-            throw new UnsupportedOperationException();
+        public void encode(List<T> value, BitChannel channel, Resolver resolver) throws IOException {
+            for (T val : value) {
+                codec.encode(val, channel, resolver);
+            }
         }
 
         public Class<?>[] getTypes() {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/NullTerminatedStringCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/NullTerminatedStringCodec.java
@@ -32,26 +32,26 @@
  */
 package org.codehaus.preon.codec;
 
-import org.codehaus.preon.*;
-import org.codehaus.preon.channel.BitChannel;
-import org.codehaus.preon.buffer.BitBuffer;
-import org.codehaus.preon.annotation.BoundString;
-import org.codehaus.preon.el.Expression;
-import nl.flotsam.pecia.SimpleContents;
-import nl.flotsam.pecia.Documenter;
-import nl.flotsam.pecia.ParaContents;
-
-import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
-
+import java.io.IOException;
+import java.io.StringWriter;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CharsetDecoder;
-import java.nio.BufferUnderflowException;
-import java.io.StringWriter;
-import java.io.IOException;
+
+import org.codehaus.preon.Builder;
+import org.codehaus.preon.Codec;
+import org.codehaus.preon.CodecDescriptor;
+import org.codehaus.preon.DecodingException;
+import org.codehaus.preon.Resolver;
+import org.codehaus.preon.annotation.BoundString;
+import org.codehaus.preon.buffer.BitBuffer;
+import org.codehaus.preon.channel.BitChannel;
+import org.codehaus.preon.el.Expression;
+
+import nl.flotsam.pecia.Documenter;
+import nl.flotsam.pecia.ParaContents;
+import nl.flotsam.pecia.SimpleContents;
 
 /**
  * A {@link org.codehaus.preon.Codec} that reads null-terminated Strings. Basically, it will read bytes until it
@@ -86,10 +86,10 @@ public class NullTerminatedStringCodec implements Codec<String> {
 		 * time. If the character decoded is NULL, it finishes up (it has
 		 * to use the decoded character, not the byte, as multibyte
 		 * encodings can include null bytes in non-null characters).
-		 * 
+		 *
 		 * I used a StringWriter for the string, as it's more memory
 		 * efficient, for what it's worth.
-		 * 
+		 *
 		 * I wasn't able to find a way to include the byteConverter in
 		 * the decoding process. I'm guessing the main use for byteConverter
 		 * was encoding conversion anyway, but if it's needed, it might

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/NullTerminatedStringCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/NullTerminatedStringCodec.java
@@ -79,6 +79,11 @@ public class NullTerminatedStringCodec implements Codec<String> {
 
     public String decode(BitBuffer buffer, Resolver resolver,
                          Builder builder) throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public String decode(BitBuffer buffer, Resolver resolver,
+                         Builder builder, boolean debug) throws DecodingException {
 		/* This has been gutted, and now uses Charsets to do decoding.
 		 * It opens the bitbuffer as a bytebuffer (taking care to note
 		 * and preserve positions), creates a CharBuffer with space for
@@ -97,31 +102,31 @@ public class NullTerminatedStringCodec implements Codec<String> {
 		 * */
         CharsetDecoder decoder = encoding.newDecoder();
         ByteBuffer bytebuffer = ByteBuffer.allocate(BUFFER_SIZE); //Allocate a bytebuffer. We'll need this for multibyte encodings
-		CharBuffer charbuffer = CharBuffer.allocate(1); //Decode one character at a time
+        CharBuffer charbuffer = CharBuffer.allocate(1); //Decode one character at a time
         StringWriter sw = new StringWriter(); //This will eventually hold our string
         byte bytevalue;
         char charvalue;
         boolean readOK = true;
-		do {
-			bytevalue = byteConverter.convert(buffer.readAsByte(8)); //Convert our byte
-			bytebuffer.put(bytevalue); // and add it to the bytebuffer
-			bytebuffer.flip(); // Flip the buffer, so we can read it
-			decoder.decode(bytebuffer,charbuffer,false); // Decode up to one char from bytebuffer
-			if (charbuffer.position() == 1) {
-				charbuffer.rewind();
-				charvalue = charbuffer.get();
-				charbuffer.rewind();
-				if (charvalue == 0) { //If character is null, we're finished
-					readOK = false;
-				}
-				else {
-					sw.append(charvalue); //Write character to StringWriter
-				}
-			}
-			bytebuffer.compact(); //Compact the buffer, so we can write to it
-		}
-		while(readOK);
-		return sw.toString();
+        do {
+            bytevalue = byteConverter.convert(buffer.readAsByte(8)); //Convert our byte
+            bytebuffer.put(bytevalue); // and add it to the bytebuffer
+            bytebuffer.flip(); // Flip the buffer, so we can read it
+            decoder.decode(bytebuffer,charbuffer,false); // Decode up to one char from bytebuffer
+            if (charbuffer.position() == 1) {
+                charbuffer.rewind();
+                charvalue = charbuffer.get();
+                charbuffer.rewind();
+                if (charvalue == 0) { //If character is null, we're finished
+                    readOK = false;
+                }
+                else {
+                    sw.append(charvalue); //Write character to StringWriter
+                }
+            }
+            bytebuffer.compact(); //Compact the buffer, so we can write to it
+        }
+        while(readOK);
+        return sw.toString();
     }
 
     public void encode(String value, BitChannel channel, Resolver resolver) throws IOException {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
@@ -220,8 +220,8 @@ public class NumericCodec implements Codec<Object> {
                 return java.lang.Float.intBitsToFloat(value);
             }
 
-            public void encode(BitChannel channel, int size, ByteOrder endian, Object value) {
-                throw new UnsupportedOperationException("Encoding not supported for floats.");
+            public void encode(BitChannel channel, int size, ByteOrder endian, Object value) throws IOException {
+            	channel.write(size, (Float) value, endian);
             }
 
             public Class<?> getType() {
@@ -241,8 +241,8 @@ public class NumericCodec implements Codec<Object> {
                         size, endian));
             }
 
-            public void encode(BitChannel channel, int size, ByteOrder endian, Object value) {
-                throw new UnsupportedOperationException("Encoding not supported for doubles.");
+            public void encode(BitChannel channel, int size, ByteOrder endian, Object value) throws IOException {
+                channel.write(size, (Double) value, endian);
             }
 
             public Class<?> getType() {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
@@ -100,6 +100,11 @@ public class NumericCodec implements Codec<Object> {
 
     public Object decode(BitBuffer buffer, Resolver resolver,
                          Builder builder) throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public Object decode(BitBuffer buffer, Resolver resolver,
+                         Builder builder, boolean debug) throws DecodingException {
         int size = ((Number) (this.sizeExpr.eval(resolver))).intValue();
         Object result = type.decode(buffer, size, byteOrder);
         if (matchExpr != null) {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
@@ -315,7 +315,11 @@ public class NumericCodec implements Codec<Object> {
             }
 
             public void encode(BitChannel channel, int size, ByteOrder endian, Object value) throws IOException {
+            	if (endian == ByteOrder.LittleEndian) {
+            		channel.writeLE(size, (Byte) value);
+            	} else {
                 channel.write(size, (Byte) value);
+            	}
             }
 
             public Class<?> getType() {

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/NumericCodec.java
@@ -315,10 +315,12 @@ public class NumericCodec implements Codec<Object> {
             }
 
             public void encode(BitChannel channel, int size, ByteOrder endian, Object value) throws IOException {
-            	if (endian == ByteOrder.LittleEndian) {
-            		channel.writeLE(size, (Byte) value);
-            	} else {
-                channel.write(size, (Byte) value);
+            	if(value != null) {
+            		if (endian == ByteOrder.LittleEndian) {
+            			channel.writeLE(size, (Byte) value);
+            		} else {
+            			channel.write(size, (Byte) value);
+            		}
             	}
             }
 

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/ObjectCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/ObjectCodec.java
@@ -75,6 +75,11 @@ public class ObjectCodec<T> implements Codec<T> {
 
     public T decode(BitBuffer buffer, Resolver resolver, Builder builder)
             throws DecodingException {
+        return decode(buffer,resolver, builder, false);
+    }
+
+    public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException {
         assert buffer != null;
         assert builder != null;
         try {
@@ -82,7 +87,7 @@ public class ObjectCodec<T> implements Codec<T> {
             resolver = context.getResolver(result, resolver);
             // TODO: I think I need a replacement resolver here.
             for (Binding binding : context.getBindings()) {
-                binding.load(result, buffer, resolver, builder);
+                binding.load(result, buffer, resolver, builder, debug);
             }
             return result;
         }

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/SelectFromCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/SelectFromCodec.java
@@ -32,24 +32,35 @@
  */
 package org.codehaus.preon.codec;
 
-import nl.flotsam.pecia.Documenter;
-import nl.flotsam.pecia.ParaContents;
-import nl.flotsam.pecia.SimpleContents;
-import nl.flotsam.pecia.Table2Cols;
-import org.codehaus.preon.*;
+import java.io.IOException;
+import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.codehaus.preon.Builder;
+import org.codehaus.preon.Codec;
+import org.codehaus.preon.CodecDescriptor;
+import org.codehaus.preon.CodecFactory;
+import org.codehaus.preon.DecodingException;
+import org.codehaus.preon.Resolver;
+import org.codehaus.preon.ResolverContext;
 import org.codehaus.preon.annotation.Choices;
 import org.codehaus.preon.buffer.BitBuffer;
 import org.codehaus.preon.buffer.ByteOrder;
 import org.codehaus.preon.channel.BitChannel;
 import org.codehaus.preon.descriptor.Documenters;
-import org.codehaus.preon.el.*;
+import org.codehaus.preon.el.BindingException;
+import org.codehaus.preon.el.ContextReplacingReference;
+import org.codehaus.preon.el.Document;
+import org.codehaus.preon.el.Expression;
+import org.codehaus.preon.el.Expressions;
+import org.codehaus.preon.el.Reference;
+import org.codehaus.preon.el.ReferenceContext;
 
-import java.io.IOException;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.List;
+import nl.flotsam.pecia.Documenter;
+import nl.flotsam.pecia.ParaContents;
+import nl.flotsam.pecia.SimpleContents;
+import nl.flotsam.pecia.Table2Cols;
 
 /**
  * A Codec supporting the {@link Choices} annotation.

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/SlicingCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/SlicingCodec.java
@@ -78,6 +78,13 @@ class SlicingCodec<T> implements Codec<T> {
         return wrapped.decode(slice, resolver, builder);
     }
 
+    public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException {
+        BitBuffer slice = buffer
+                .slice(sizeExpr.eval(resolver));
+        return wrapped.decode(slice, resolver, builder, debug);
+    }
+
     public void encode(T value, BitChannel channel, Resolver resolver) throws IOException {
         wrapped.encode(value, new BoundedBitChannel(channel, sizeExpr.eval(resolver)), resolver);
     }

--- a/preon-binding/src/main/java/org/codehaus/preon/codec/SwitchingCodec.java
+++ b/preon-binding/src/main/java/org/codehaus/preon/codec/SwitchingCodec.java
@@ -80,6 +80,12 @@ public class SwitchingCodec implements Codec<Object> {
         return codec.decode(buffer, resolver, builder);
     }
 
+    public Object decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException {
+        Codec<?> codec = selector.select(buffer, resolver);
+        return codec.decode(buffer, resolver, builder, debug);
+    }
+
     public void encode(Object value, BitChannel channel, Resolver resolver) throws IOException {
         Codec codec = selector.select(value.getClass(), channel, resolver);
         codec.encode(value, channel, resolver);

--- a/preon-el/pom.xml
+++ b/preon-el/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr-runtime</artifactId>
-      <version>3.3</version>
+      <version>3.5.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -66,7 +66,7 @@
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr3-maven-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.5.2</version>
         <executions>
             <execution>
                 <phase>generate-sources</phase>

--- a/preon-emitter/src/main/java/org/codehaus/preon/emitter/EmittingBinding.java
+++ b/preon-emitter/src/main/java/org/codehaus/preon/emitter/EmittingBinding.java
@@ -64,6 +64,13 @@ public class EmittingBinding implements Binding {
         emitter.markEndLoad();
     }
 
+    public void load(Object object, BitBuffer buffer, Resolver resolver, Builder builder,
+                     boolean debug) throws DecodingException {
+        emitter.markStartLoad(binding.getName(), object);
+        binding.load(object, buffer, resolver, builder, debug);
+        emitter.markEndLoad();
+    }
+
     public <V extends SimpleContents<?>> V describe(V contents) {
         return binding.describe(contents);
     }

--- a/preon-emitter/src/main/java/org/codehaus/preon/emitter/EmittingCodec.java
+++ b/preon-emitter/src/main/java/org/codehaus/preon/emitter/EmittingCodec.java
@@ -74,6 +74,11 @@ public class EmittingCodec<T> implements Codec<T> {
 
     public T decode(BitBuffer buffer, Resolver resolver, Builder builder)
             throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public T decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug)
+            throws DecodingException {
         T result = null;
         long pos = buffer.getActualBitPos();
         emitter.markStart(codec, pos, buffer);

--- a/preon-io/pom.xml
+++ b/preon-io/pom.xml
@@ -38,7 +38,7 @@
       <version>1.3.1</version>
     </dependency>
     <dependency>
-      <groupId>multithreadedtc</groupId>
+      <groupId>edu.umd.cs.mtc</groupId>
       <artifactId>multithreadedtc</artifactId>
       <version>1.01</version>
       <scope>test</scope>

--- a/preon-io/src/main/java/org/codehaus/preon/buffer/DefaultBitBuffer.java
+++ b/preon-io/src/main/java/org/codehaus/preon/buffer/DefaultBitBuffer.java
@@ -37,6 +37,7 @@ import org.apache.commons.logging.LogFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
@@ -343,18 +344,21 @@ public class DefaultBitBuffer implements BitBuffer {
      * @param nrBits    number of bits to read
      * @return shifted integer buffer
      */
-    private static long getRightShiftedNumberBufAsLong(long numberBuf,
+    private static long getRightShiftedNumberBufAsLong(BigInteger numberBuf,
                                                        long bitPos, int nrBits, ByteOrder byteOrder) throws BitBufferException {
 
         // number of bits integer buffer needs to be shifted to the right in
         // order to reach the last bit in last byte
-        long shiftBits;
+        int shiftBits;
         if (byteOrder == ByteOrder.BigEndian)
-            shiftBits = 7 - ((nrBits + bitPos + 7) % 8);
+            shiftBits = (int)(7 - ((nrBits + bitPos + 7) % 8));
         else
-            shiftBits = bitPos % 8;
+            shiftBits = (int)(bitPos % 8);
 
-        return numberBuf >> shiftBits;
+
+        numberBuf = numberBuf.shiftRight(shiftBits);
+
+        return numberBuf.longValue();
     }
 
     /**
@@ -391,19 +395,30 @@ public class DefaultBitBuffer implements BitBuffer {
      * @param firstBytePos position of the first byte that is necessary to be read
      * @return value of all read bytes, containing specified bits
      */
-    private long getNumberBufAsLong(ByteOrder byteOrder, int nrReadBytes,
+    private BigInteger getNumberBufAsLong(ByteOrder byteOrder, int nrReadBytes,
                                     int firstBytePos) {
-
-        long result = 0L;
-        long bytePortion = 0L;
+        BigInteger result = BigInteger.valueOf(0);
+        long bytePortion = 0;
         for (int i = 0; i < nrReadBytes; i++) {
             bytePortion = 0xFF & (byteBuffer.get(firstBytePos++));
 
-            if (byteOrder == ByteOrder.LittleEndian)
-                // reshift bytes
-                result = result | bytePortion << (i << 3);
-            else
-                result = bytePortion << ((nrReadBytes - i - 1) << 3) | result;
+            //Need to use BigInteger because it is possible that a 64-bit field spans 9 bytes
+            if (byteOrder == ByteOrder.LittleEndian) {
+                BigInteger shifter = BigInteger.valueOf(2);
+                shifter = shifter.pow(i*8);
+
+                BigInteger bytePortionBigInt = BigInteger.valueOf(bytePortion);
+                bytePortionBigInt = bytePortionBigInt.multiply(shifter);
+                result = result.add(bytePortionBigInt);
+            }
+            else {
+                BigInteger shifter = BigInteger.valueOf(2);
+                shifter = shifter.pow(8);
+                BigInteger bytePortionBigInt = BigInteger.valueOf(bytePortion);
+
+                result = result.multiply(shifter);
+                result = result.add(bytePortionBigInt);
+            }
         }
 
         return result;
@@ -523,7 +538,7 @@ public class DefaultBitBuffer implements BitBuffer {
         int nrReadBytes = getNrNecessaryBytes(bitPos, nrBits);
 
         // buffer containing specified bits
-        long numberBuf = getNumberBufAsLong(byteOrder, nrReadBytes,
+        BigInteger numberBuf = getNumberBufAsLong(byteOrder, nrReadBytes,
                 (int) (bitPos >> 3));
 
         // mask leaving only specified bits

--- a/preon-io/src/main/java/org/codehaus/preon/channel/BitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/BitChannel.java
@@ -52,9 +52,21 @@ public interface BitChannel {
 
     /** Writes <code>nrbits</code> bits of the byte to the channel in Big Endian. */
     void write(int nrbits, byte value) throws IOException;
-    
+
     /** Writes <code>nrbits</code> bits of the byte to the channel in Little Endian. */
     void writeLE(int nrbits, byte value) throws IOException;
+    
+    /**
+     * Writes <code>nrbits</code> bits of the float value to the channel, based on the {@link ByteOrder} passed in, in
+     * case the number of bits exceeds 8.
+     */
+    void write(int nrbits, float value, ByteOrder byteOrder) throws IOException;
+
+    /**
+     * Writes <code>nrbits</code> bits of the double value to the channel, based on the {@link ByteOrder} passed in, in
+     * case the number of bits exceeds 8.
+     */
+    void write(int nrbits, double value, ByteOrder byteOrder) throws IOException;
 
     /**
      * Writes <code>nrbits</code> bits of the int value to the channel, based on the {@link ByteOrder} passed in, in
@@ -88,7 +100,7 @@ public interface BitChannel {
 
     /** Closes the channel. */
     void close() throws IOException;
-    
+
     /** Flush any remaining bits. */
     void flush(ByteOrder byteOrder) throws IOException;
 }

--- a/preon-io/src/main/java/org/codehaus/preon/channel/BitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/BitChannel.java
@@ -90,5 +90,5 @@ public interface BitChannel {
     void close() throws IOException;
     
     /** Flush any remaining bits. */
-    void flush() throws IOException;
+    void flush(ByteOrder byteOrder) throws IOException;
 }

--- a/preon-io/src/main/java/org/codehaus/preon/channel/BitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/BitChannel.java
@@ -48,10 +48,13 @@ public interface BitChannel {
      * Writes the boolean value as a bit to the channel. (Writes an 1 in case of <code>true</code> value, and 0
      * otherwise.)
      */
-    void write(boolean value) throws IOException;
+    void write(boolean value, ByteOrder byteOrder) throws IOException;
 
-    /** Writes <code>nrbits</code> bits of the byte to the channel. */
+    /** Writes <code>nrbits</code> bits of the byte to the channel in Big Endian. */
     void write(int nrbits, byte value) throws IOException;
+    
+    /** Writes <code>nrbits</code> bits of the byte to the channel in Little Endian. */
+    void writeLE(int nrbits, byte value) throws IOException;
 
     /**
      * Writes <code>nrbits</code> bits of the int value to the channel, based on the {@link ByteOrder} passed in, in
@@ -85,5 +88,7 @@ public interface BitChannel {
 
     /** Closes the channel. */
     void close() throws IOException;
-
+    
+    /** Flush any remaining bits. */
+    void flush() throws IOException;
 }

--- a/preon-io/src/main/java/org/codehaus/preon/channel/BoundedBitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/BoundedBitChannel.java
@@ -80,7 +80,7 @@ public class BoundedBitChannel implements BitChannel {
             throw new IOException(OVERRUN_MESSAGE);
         }
     }
-    
+
     public void writeLE(int nrbits, byte value) throws IOException {
       if (written + nrbits <= maxBits) {
           channel.writeLE(nrbits, value);
@@ -88,7 +88,25 @@ public class BoundedBitChannel implements BitChannel {
       } else {
           throw new IOException(OVERRUN_MESSAGE);
       }
-  }
+    }
+    
+    public void write(int nrbits, float value, ByteOrder byteOrder) throws IOException {
+        if (written + nrbits <= maxBits) {
+            channel.write(nrbits, value, byteOrder);
+            written += nrbits;
+        } else {
+            throw new IOException(OVERRUN_MESSAGE);
+        }
+    }
+
+    public void write(int nrbits, double value, ByteOrder byteOrder) throws IOException {
+        if (written + nrbits <= maxBits) {
+            channel.write(nrbits, value, byteOrder);
+            written += nrbits;
+        } else {
+            throw new IOException(OVERRUN_MESSAGE);
+        }
+    }
 
     public void write(int nrbits, int value, ByteOrder byteOrder) throws IOException {
         if (written + nrbits <= maxBits) {

--- a/preon-io/src/main/java/org/codehaus/preon/channel/BoundedBitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/BoundedBitChannel.java
@@ -143,9 +143,8 @@ public class BoundedBitChannel implements BitChannel {
     public void close() throws IOException {
         channel.close();
     }
-    
-    
-    public void flush() throws IOException {
-    		channel.flush();
+
+    public void flush(ByteOrder byteOrder) throws IOException {
+        channel.flush(byteOrder);
     }
 }

--- a/preon-io/src/main/java/org/codehaus/preon/channel/BoundedBitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/BoundedBitChannel.java
@@ -63,9 +63,9 @@ public class BoundedBitChannel implements BitChannel {
         this.maxBits = maxBits;
     }
 
-    public void write(boolean value) throws IOException {
+    public void write(boolean value, ByteOrder byteOrder) throws IOException {
         if (written + 1 <= maxBits) {
-            channel.write(value);
+            channel.write(value, byteOrder);
             written += 1;
         } else {
             throw new IOException(OVERRUN_MESSAGE);
@@ -80,6 +80,15 @@ public class BoundedBitChannel implements BitChannel {
             throw new IOException(OVERRUN_MESSAGE);
         }
     }
+    
+    public void writeLE(int nrbits, byte value) throws IOException {
+      if (written + nrbits <= maxBits) {
+          channel.writeLE(nrbits, value);
+          written += nrbits;
+      } else {
+          throw new IOException(OVERRUN_MESSAGE);
+      }
+  }
 
     public void write(int nrbits, int value, ByteOrder byteOrder) throws IOException {
         if (written + nrbits <= maxBits) {
@@ -133,5 +142,10 @@ public class BoundedBitChannel implements BitChannel {
 
     public void close() throws IOException {
         channel.close();
+    }
+    
+    
+    public void flush() throws IOException {
+    		channel.flush();
     }
 }

--- a/preon-io/src/main/java/org/codehaus/preon/channel/OutputStreamBitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/OutputStreamBitChannel.java
@@ -92,7 +92,7 @@ public class OutputStreamBitChannel implements BitChannel, Closeable {
             buffer = 0;
         }
     }
-    
+
     public void writeLE(@Nonnegative int nrbits, byte value) throws IOException {
         assert nrbits > 0;
         assert nrbits <= 8;
@@ -110,7 +110,7 @@ public class OutputStreamBitChannel implements BitChannel, Closeable {
 
         // Check if the buffer needs to be flushed
         if (bitPos > 7) {
-            out.write(buffer);   
+            out.write(buffer);
             buffer = 0;
             bitPos = 0;
         }
@@ -118,10 +118,10 @@ public class OutputStreamBitChannel implements BitChannel, Closeable {
         // Check if there is something else left to copy
         if (length < nrbits) {
         	bitPos = nrbits - length;
-        	
+
           // Chop off bits not required
           value = (byte) (0xff & MASK_UPPER[bitPos] & (value >> length));
-          
+
           // Fill the buffer
           buffer = (byte) (buffer | (0xff & value));
         }
@@ -156,6 +156,16 @@ public class OutputStreamBitChannel implements BitChannel, Closeable {
             buffer = (byte) (MASK_UPPER[nrbits - length] & value);
             bitPos = nrbits - length;
         }
+    }
+    
+    public void write(@Nonnegative int nrbits, float value, ByteOrder byteOrder)
+            throws IOException {
+    	write(nrbits, Float.floatToIntBits(value), byteOrder);
+    }
+
+    public void write(@Nonnegative int nrbits, double value, ByteOrder byteOrder)
+            throws IOException {
+    	write(nrbits, Double.doubleToLongBits(value), byteOrder);
     }
 
     public void write(@Nonnegative int nrbits, int value, ByteOrder byteOrder)
@@ -249,16 +259,16 @@ public class OutputStreamBitChannel implements BitChannel, Closeable {
     public void close() throws IOException {
         out.close();
     }
-    
+
     public void flush(ByteOrder byteOrder) throws IOException {
     		assert bitPos < 8;
     		if (bitPos > 0) {
-    	  				int remaining = 8 - bitPos; 
+    	  				int remaining = 8 - bitPos;
     	  				if (byteOrder == ByteOrder.LittleEndian) {
     	  				    writeLE(remaining, (byte)0);
     	  				} else {
     	  					  write(remaining, (byte)0);
-    	  				}	
+    	  				}
     	  }
     	  out.flush();
     }

--- a/preon-io/src/main/java/org/codehaus/preon/channel/OutputStreamBitChannel.java
+++ b/preon-io/src/main/java/org/codehaus/preon/channel/OutputStreamBitChannel.java
@@ -249,12 +249,16 @@ public class OutputStreamBitChannel implements BitChannel, Closeable {
     public void close() throws IOException {
         out.close();
     }
-
-    public void flush() throws IOException {
+    
+    public void flush(ByteOrder byteOrder) throws IOException {
     		assert bitPos < 8;
     		if (bitPos > 0) {
     	  				int remaining = 8 - bitPos; 
-    	  				write(remaining, (byte)0);
+    	  				if (byteOrder == ByteOrder.LittleEndian) {
+    	  				    writeLE(remaining, (byte)0);
+    	  				} else {
+    	  					  write(remaining, (byte)0);
+    	  				}	
     	  }
     	  out.flush();
     }

--- a/preon-io/src/test/java/org/codehaus/preon/channel/OutputStreamBitChannelTest.java
+++ b/preon-io/src/test/java/org/codehaus/preon/channel/OutputStreamBitChannelTest.java
@@ -58,15 +58,15 @@ public class OutputStreamBitChannelTest {
     @Test
     public void shouldAcceptBooleans() throws IOException {
         OutputStreamBitChannel channel = new OutputStreamBitChannel(out);
-        channel.write(true);
-        channel.write(true);
-        channel.write(true);
-        channel.write(true);
-        channel.write(false);
-        channel.write(false);
-        channel.write(false);
-        channel.write(false);
-        channel.write(false);
+        channel.write(true, ByteOrder.BigEndian);
+        channel.write(true, ByteOrder.BigEndian);
+        channel.write(true, ByteOrder.BigEndian);
+        channel.write(true, ByteOrder.BigEndian);
+        channel.write(false, ByteOrder.BigEndian);
+        channel.write(false, ByteOrder.BigEndian);
+        channel.write(false, ByteOrder.BigEndian);
+        channel.write(false, ByteOrder.BigEndian);
+        channel.write(false, ByteOrder.BigEndian);
         verify(out).write((byte) 0xf0);
         verifyNoMoreInteractions(out);
     }
@@ -136,9 +136,9 @@ public class OutputStreamBitChannelTest {
         channel.write(12, (int) 0xf00, ByteOrder.LittleEndian); // 1111 0000 0000 
         channel.write(4, (int) 0x0, ByteOrder.LittleEndian); // 0000
         // What I expect:
-        // 0000 0000 1111 0000
+        // 0000 0000 0000 1111
         verify(out).write((byte) Integer.parseInt("00000000", 2));
-        verify(out).write((byte) Integer.parseInt("11110000", 2));
+        verify(out).write((byte) Integer.parseInt("00001111", 2));
         verifyNoMoreInteractions(out);
     }
 

--- a/preon-samples/preon-sample-varlength-encoding/src/main/java/org/codehaus/preon/sample/varlength/VariableLengthByteArrayCodec.java
+++ b/preon-samples/preon-sample-varlength-encoding/src/main/java/org/codehaus/preon/sample/varlength/VariableLengthByteArrayCodec.java
@@ -50,6 +50,10 @@ import nl.flotsam.pecia.SimpleContents;
 public class VariableLengthByteArrayCodec implements Codec<byte[]> {
 
     public byte[] decode(BitBuffer buffer, Resolver resolver, Builder builder) throws DecodingException {
+        return decode(buffer, resolver, builder, false);
+    }
+
+    public byte[] decode(BitBuffer buffer, Resolver resolver, Builder builder, boolean debug) throws DecodingException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         boolean cont = true;
         while (cont) {


### PR DESCRIPTION
Added support for little endian encoding. It appears that the current
implementation of little endian decoding uses LSB 0 bit numbering.
However, the encoding seems to only encode with MSB 0 bit numbering.  I
attempted to resolve this issue and it is currently working for
Numerics.
